### PR TITLE
Work around remaining issue in FileWave 10.1 with QObject prints

### DIFF
--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -126,7 +126,8 @@ class FWAdminClient(object):
         try:
             if print_output:
                 print process_options
-            self.run_result_ret = subprocess.check_output(process_options, stderr=subprocess.STDOUT).rstrip()
+            self.run_result_ret = subprocess.check_output(process_options,stderr=subprocess.STDOUT).rstrip()
+            self.run_result_ret = re.sub("QObject::connect.*QNetworkSession::State\)\n", '', self.run_result_ret)
         except CalledProcessError as e:
             got_error = True
             if print_output:


### PR DESCRIPTION
Unfortunately FileWave 10.1.1 will not filter out these messages from command line output.
we need to filter them out manually in commandline.py file
