### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Adium/Adium.filewave.recipe
+++ b/Adium/Adium.filewave.recipe
@@ -13,7 +13,7 @@
         <key>fw_app_bundle_id</key>
         <string>com.github.autopkg.filewave.Adium</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Adium.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
@@ -48,9 +48,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Adium.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Adium.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>Copier</string>
@@ -63,7 +63,7 @@
 				<key>fw_app_version</key>
 				<string>%version%</string>
 				<key>fw_import_source</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Adium.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/AdobeAIR/AdobeAIR.filewave.recipe
+++ b/AdobeAIR/AdobeAIR.filewave.recipe
@@ -16,7 +16,7 @@ Based on jamesz's work here: https://github.com/jamesez/automunki/tree/master/ad
         <key>fw_app_bundle_id</key>
         <string>com.github.autopkg.pkg.AdobeAIR</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/AdobeAIR.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/CyberDuck/Cyberduck.filewave.recipe
+++ b/CyberDuck/Cyberduck.filewave.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Cyberduck</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Cyberduck.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.3.0</string>
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Cyberduck.app</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleIdentifier</key>
@@ -54,7 +54,7 @@
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Cyberduck.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/Evernote/Evernote.filewave.recipe
+++ b/Evernote/Evernote.filewave.recipe
@@ -17,7 +17,7 @@ http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
         <key>fw_app_bundle_id</key>
         <string>com.evernote.Evernote</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Evernote.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.1</string>
@@ -48,7 +48,7 @@ http://update.evernote.com/prerelease/ENMac/EvernoteMacUpdate.xml
 				<key>fw_fileset_name</key>
 				<string>%NAME% - %version%</string>
 				<key>fw_import_source</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Evernote.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>com.github.autopkg.filewave.FWTool/FileWaveImporter</string>

--- a/GoogleChrome/GoogleChrome.filewave.recipe
+++ b/GoogleChrome/GoogleChrome.filewave.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Google Chrome</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Google Chrome.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>

--- a/GoogleEarth/GoogleEarth.filewave.recipe
+++ b/GoogleEarth/GoogleEarth.filewave.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Google Earth</string>
         <key>fw_destination_root</key>
-        <string>/Applications/%NAME%.app</string>
+        <string>/Applications/Google Earth.app</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.