### PR TITLE
Basic python3 compatibility

### DIFF
--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -122,6 +122,13 @@ class FWAdminClient(object):
         process_options = [self.fwadmin_executable]
         if include_connection_options:
             process_options.extend(self.connection_options)
+
+        # Map string type for both Python 2 and Python 3.
+        try:
+            _ = basestring
+        except NameError:
+            basestring = str  # pylint: disable=W0622
+
         if isinstance(options, basestring):
             process_options.append(options)
         else:

--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -144,8 +144,8 @@ class FWAdminClient(object):
                 print(process_options)
 
             self.run_result_ret = subprocess.check_output(process_options, stderr=subprocess.STDOUT).rstrip()
-            self.run_result_ret = re.sub("QObject::connect.*QNetworkSession::State\)\n", '', self.run_result_ret)
-            self.run_result_ret = re.sub("qt.network.ssl: Error receiving trust for a CA certificate\n", '', self.run_result_ret)
+            self.run_result_ret = re.sub(r"QObject::connect.*QNetworkSession::State\)\n", '', self.run_result_ret)
+            self.run_result_ret = re.sub(r"qt.network.ssl: Error receiving trust for a CA certificate\n", '', self.run_result_ret)
 
         except CalledProcessError as e:
             got_error = True

--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 import subprocess
 from subprocess import CalledProcessError
 import re, os
@@ -130,7 +132,7 @@ class FWAdminClient(object):
         self.run_result_ret = None
         try:
             if print_output:
-                print process_options
+                print(process_options)
 
             self.run_result_ret = subprocess.check_output(process_options, stderr=subprocess.STDOUT).rstrip()
             self.run_result_ret = re.sub("QObject::connect.*QNetworkSession::State\)\n", '', self.run_result_ret)
@@ -139,8 +141,8 @@ class FWAdminClient(object):
         except CalledProcessError as e:
             got_error = True
             if print_output:
-                print "Command failed, error code: ", e.returncode
-                print "Ouput: ", e.output
+                print("Command failed, error code: ", e.returncode)
+                print("Ouput: ", e.output)
             if not error_expected:
                 raise e
             else:
@@ -299,7 +301,7 @@ class FWAdminClient(object):
         if target:
             options.extend(["--filesetgroup", str(target)])
         create_empty_fileset_result = self.run_admin(options)
-        print create_empty_fileset_result
+        print(create_empty_fileset_result)
         matcher = re.compile(r'new fileset (?P<id>.+) created with name (?P<name>.+)')
         search = matcher.search(create_empty_fileset_result)
         id = search.group('id')

--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -1,11 +1,13 @@
-from __future__ import absolute_import
-from __future__ import print_function
+from __future__ import absolute_import, print_function
+
+import json
+import os
+import os.path
+import platform
+import re
 import subprocess
 from subprocess import CalledProcessError
-import re, os
-import json
-import platform
-import os.path
+
 
 class Client(object):
     def __init__(self, id, name, type, parent_id, **kwargs):

--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -143,7 +143,7 @@ class FWAdminClient(object):
             if print_output:
                 print(process_options)
 
-            self.run_result_ret = subprocess.check_output(process_options, stderr=subprocess.STDOUT).rstrip()
+            self.run_result_ret = subprocess.check_output(process_options, stderr=subprocess.STDOUT).decode().rstrip()
             self.run_result_ret = re.sub(r"QObject::connect.*QNetworkSession::State\)\n", '', self.run_result_ret)
             self.run_result_ret = re.sub(r"qt.network.ssl: Error receiving trust for a CA certificate\n", '', self.run_result_ret)
 

--- a/FWTool/FWTool.py
+++ b/FWTool/FWTool.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 
 """See docstring for FWTool class"""
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import DmgMounter, Processor, ProcessorError
+from __future__ import absolute_import, print_function
 
 import os
 import os.path
-from subprocess import CalledProcessError
 import sys
+from subprocess import CalledProcessError
+
+from autopkglib import DmgMounter, Processor, ProcessorError
 
 # Ensure that the FWAdminClient can be imported from CommandLine module, since
 # this Processor was imported via autopkg explicitly, the directory is not in
@@ -153,4 +153,3 @@ class FWTool(DmgMounter):
 if __name__ == '__main__':
     PROCESSOR = FWTool()
     PROCESSOR.execute_shell()
-

--- a/FWTool/FWTool.py
+++ b/FWTool/FWTool.py
@@ -117,7 +117,7 @@ class FWTool(DmgMounter):
         except CalledProcessError as e:
             self.exception = e
             self.exit_status_message = FWAdminClient.ExitStatusDescription[e.returncode][1]
-        except BaseException as e:
+        except Exception as e:
             self.exception = e
 
         if self.env['FW_ADMIN_USER'] == 'fwadmin':

--- a/FWTool/FWTool.py
+++ b/FWTool/FWTool.py
@@ -117,7 +117,7 @@ class FWTool(DmgMounter):
         except CalledProcessError as e:
             self.exception = e
             self.exit_status_message = FWAdminClient.ExitStatusDescription[e.returncode][1]
-        except Exception as e:
+        except BaseException as e:
             self.exception = e
 
         if self.env['FW_ADMIN_USER'] == 'fwadmin':

--- a/FWTool/FWTool.py
+++ b/FWTool/FWTool.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 """See docstring for FWTool class"""
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import DmgMounter, Processor, ProcessorError
 
 import os
@@ -94,7 +96,7 @@ class FWTool(DmgMounter):
         )
 
         if print_path:
-            print "Path to Admin Tool:", FWAdminClient.get_admin_tool_path()
+            print("Path to Admin Tool:", FWAdminClient.get_admin_tool_path())
 
         self.version = self.client.get_version()
         self.major, self.minor, self.patch = self.version.split('.')
@@ -112,10 +114,10 @@ class FWTool(DmgMounter):
             the_filesets = self.client.get_filesets()
             count_filesets = sum(1 for i in the_filesets)
             self.can_list_filesets = "Yes" if count_filesets >= 0 else "No"
-        except CalledProcessError, e:
+        except CalledProcessError as e:
             self.exception = e
             self.exit_status_message = FWAdminClient.ExitStatusDescription[e.returncode][1]
-        except Exception, e:
+        except Exception as e:
             self.exception = e
 
         if self.env['FW_ADMIN_USER'] == 'fwadmin':
@@ -146,7 +148,7 @@ class FWTool(DmgMounter):
             }}
 
         if self.exception is not None:
-            print self.exception
+            print(self.exception)
 
 if __name__ == '__main__':
     PROCESSOR = FWTool()

--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """See docstring for FileWaveImporter class"""
+from __future__ import absolute_import
+from __future__ import print_function
 from autopkglib import Processor, ProcessorError
 from distutils.version import LooseVersion, StrictVersion
 import glob
@@ -110,8 +112,8 @@ class FileWaveImporter(FWTool):
 
                 if app_bundle_id == fw_app_bundle_id and \
                                 LooseVersion(app_version) >= LooseVersion(fw_app_version):
-                    print "This app version is already satisfied by the fileset %s called '%s' (%s, %s)" %\
-                          (fileset.id, fileset.name, fw_app_bundle_id, fw_app_version )
+                    print("This app version is already satisfied by the fileset %s called '%s' (%s, %s)" %\
+                          (fileset.id, fileset.name, fw_app_bundle_id, fw_app_version ))
                     return
 
         import_source = self.env['fw_import_source']
@@ -168,7 +170,7 @@ class FileWaveImporter(FWTool):
                     self.client.set_property(fileset_id, "autopkg_app_bundle_id", fw_app_bundle_id)
                     self.client.set_property(fileset_id, "autopkg_app_version", fw_app_version)
 
-            except Exception, e:
+            except Exception as e:
                 raise ProcessorError("Error importing the folder '%s' into FileWave as a fileset called '%s'.  Reason: %s" %
                                      (import_source, fileset_name, e))
 

--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -170,7 +170,7 @@ class FileWaveImporter(FWTool):
                     self.client.set_property(fileset_id, "autopkg_app_bundle_id", fw_app_bundle_id)
                     self.client.set_property(fileset_id, "autopkg_app_version", fw_app_version)
 
-            except BaseException as e:
+            except Exception as e:
                 raise ProcessorError("Error importing the folder '%s' into FileWave as a fileset called '%s'.  Reason: %s" %
                                      (import_source, fileset_name, e))
 

--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -14,23 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """See docstring for FileWaveImporter class"""
-from __future__ import absolute_import
-from __future__ import print_function
-from autopkglib import Processor, ProcessorError
-from distutils.version import LooseVersion, StrictVersion
-import glob
+from __future__ import absolute_import, print_function
 
+import glob
 import os
 import os.path
 import sys
+from distutils.version import LooseVersion
+
+from autopkglib import Processor, ProcessorError
 
 # Ensure that the FWAdminClient can be imported from CommandLine module, since
 # this Processor was imported via autopkg explicitly, the directory is not in
 # the search path.
 sys.path.append(os.path.dirname(__file__))
-
 from CommandLine import FWAdminClient
 from FWTool import COMMON_FILEWAVE_VARIABLES, FWTool
+
 
 __version__ = "0.0.1"
 FW_FILESET_DESTINATION = "/Applications"

--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -170,7 +170,7 @@ class FileWaveImporter(FWTool):
                     self.client.set_property(fileset_id, "autopkg_app_bundle_id", fw_app_bundle_id)
                     self.client.set_property(fileset_id, "autopkg_app_version", fw_app_version)
 
-            except Exception as e:
+            except BaseException as e:
                 raise ProcessorError("Error importing the folder '%s' into FileWave as a fileset called '%s'.  Reason: %s" %
                                      (import_source, fileset_name, e))
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.