### PR TITLE
Add model update override 

### DIFF
--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -54,6 +54,10 @@ class FileWaveImporter(FWTool):
             "required": False,
             "description": "The name of the fileset group to import into - can be left blank, will be created if it does not exist.",
         },
+          "fw_update_model": {
+            "required": False,
+            "description": "Should the model be updated",
+        },
         "fw_destination_root": {
             "default": FW_FILESET_DESTINATION,
             "required": False,
@@ -175,6 +179,10 @@ class FileWaveImporter(FWTool):
                                      (import_source, fileset_name, e))
 
         finally:
+            model_update = self.env.get('fw_model_update', None)
+            if model_update == True:
+                self.client.model_update()
+                
             if dmg_mountpoint is not None:
                 self.unmount(dmg_mountpoint)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ use of the --updateModel feature of the Admin CLI):
 Then on the machine running autopkg, set the FW_ADMIN_USER value:
 
     defaults write com.github.autopkg FW_ADMIN_USER autopkg
+
+To enable model update on an override add:
+    
+    <key>fw_model_update</key>
+    <true/>
     
 # Validation of the setup
 In order to quickly validate whether or not your setup is working you can run


### PR DESCRIPTION
This adds a method to use the model_update function from an override and updates the README with instructions. See #26 

To enable model update on an override add:

    <key>fw_model_update</key>
    <true/>