### PR TITLE
Export fileset to file after new autopkg-fileset is imported in filewave

### DIFF
--- a/FWTool/CommandLine.py
+++ b/FWTool/CommandLine.py
@@ -234,7 +234,7 @@ class FWAdminClient(object):
         return id
 
     def export_fileset(self, destination, fs_name):
-        options = [ '--exportFileset', destination, '--fileset', fs_name ]
+        options = [ '--exportFileset', destination, '--fileset', fs_name, '--name', fs_name]
         export_result = self.run_admin(options)
         matcher = re.compile(r'the fileset with ID (?P<id>.+) was exported to \'(?P<to>.+)\'')
         search = matcher.search(export_result)

--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -60,6 +60,10 @@ class FileWaveImporter(FWTool):
             "description": ("The location at which to place all the imported data.  Defaults to %s"
                              % FW_FILESET_DESTINATION )
         },
+        "fw_export_fileset": {
+            "required": False,
+            "description": "Should the fileset be exported to specified path",
+        },
         "fw_app_bundle_id": {
             "default": None,
             "required": False,
@@ -178,6 +182,11 @@ class FileWaveImporter(FWTool):
         finally:
             if dmg_mountpoint is not None:
                 self.unmount(dmg_mountpoint)
+
+            export_fileset = self.env.get('fw_export_fileset', None)
+            if export_fileset is not None:
+                if export_fileset != "":
+                    self.client.export_fileset(export_fileset, fileset_name)
 
 if __name__ == '__main__':
     PROCESSOR = FileWaveImporter()


### PR DESCRIPTION
When adding this..

```
<key>fw_export_fileset</key>
<string>/some/useful/path</string>
```
.. to the recipe. The newly created fileset wil be directly exported to file in the path specified.

When not set or string is empty. The fileset wil not be exported.

Can be useful for archiving-purposes