### PR TITLE
Changing "distutils.version" to "packaging.version" for better version comparison

### DIFF
--- a/FWTool/FileWaveImporter.py
+++ b/FWTool/FileWaveImporter.py
@@ -20,7 +20,7 @@ import glob
 import os
 import os.path
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from autopkglib import Processor, ProcessorError
 
@@ -151,7 +151,7 @@ class FileWaveImporter(FWTool):
 
                 if app_bundle_id is not None and app_version is not None and \
                                 app_bundle_id == fw_app_bundle_id and \
-                                LooseVersion(app_version) >= LooseVersion(fw_app_version):
+                                Version(app_version) >= Version(fw_app_version):
                     print("This app version is already satisfied by the fileset %s called '%s' (%s, %s)" %\
                           (fileset.id, fileset.name, fw_app_bundle_id, fw_app_version ))
                     return


### PR DESCRIPTION
"distutils" will be deprecated in the future (see: https://docs.python.org/3/library/distutils.html)

I should be replaced with "packaging.version" 
(https://packaging.pypa.io/en/latest/version.html)

Added advantage: comparing version numbers with letters vs numeric was 
not possible with "LooseVersion"
f.e.: You could not compare 4.0.1 with 4.0.b2, it gave an error
With "packaging.version" you are able to compare this. In this example 
4.0.1 will be "greater" then 4.0.b2