### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/FWTool/FWTool.filewave.recipe
+++ b/FWTool/FWTool.filewave.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml</string>
+		<string>https://update.evernote.com/public/ENMac/EvernoteMacUpdate.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.5.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!